### PR TITLE
Fix config validation errors

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -3,23 +3,22 @@ import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
 export interface Config {
     catalog?: {
         providers?: {
-            kubernetes?: Record<
-                string,
-                {
-                    cluster: string;
-                    filters?: {
-                        resources?: Array<any>;
-                        namespace?: string;
-                        labelSelector?: string
-                    }
-                    processor?: {
-                        namespaceOverride?: string;
-                        lifecyle?: string;
-                        defaultOwner?: string;
-                    }
-                    schedule?: TaskScheduleDefinitionConfig;
-                }
-            >
+            kubernetes?: {
+              [key: string]: {
+                cluster: string;
+                filters?: {
+                  resources?: Array<any>;
+                  namespace?: string;
+                  labelSelector?: string;
+                };
+                processor?: {
+                  namespaceOverride?: string;
+                  lifecyle?: string;
+                  defaultOwner?: string;
+                };
+                schedule?: TaskScheduleDefinitionConfig;
+              };
+            }
         };
     };
 }


### PR DESCRIPTION
Bumping backstage to 0.25.1 causes the following validation error:

```
Backend failed to start up Error: Invalid configuration schema in ../../node_modules/@antoinedao/backstage-provider-kubernetes/config.d.ts, the following definitions are not supported:

Record<string,{cluster:string;filters?:{resources?:any[]|undefined;namespace?:string|undefined;labelSelector?:string|undefined;}|undefined;processor?:{namespaceOverride?:string|undefined;lifecyle?:string|undefined;defaultOwner?:string|undefined;}|undefined;schedule?:any;}>
```
It appears that `Record` is not supported